### PR TITLE
Add <array> header to fix compilation with gcc 12

### DIFF
--- a/client/src/main.cpp
+++ b/client/src/main.cpp
@@ -8,6 +8,7 @@
 #include <unistd.h>
 #include <uuid/uuid.h>
 
+#include <array>
 #include <chrono>
 #include <cstring>
 #include <ctime>

--- a/server/src/main.cpp
+++ b/server/src/main.cpp
@@ -8,6 +8,7 @@
 #include <unistd.h>
 #include <uuid/uuid.h>
 
+#include <array>
 #include <chrono>
 #include <cstring>
 #include <iostream>


### PR DESCRIPTION
Users of std::array should include it.

Signed-off-by: Eneas U de Queiroz <cotequeiroz@gmail.com>

---

This is the error I get, with the proposed solution:
```
src/main.cpp:117:10: error: field 'uuid' has incomplete type 'MyUuid' {aka 'std::array<char, 16>'}
  117 |   MyUuid uuid{};
      |          ^~~~
In file included from /builder/shared-workdir/build/sdk/staging_dir/toolchain-aarch64_cortex-a53_gcc-12.2.0_musl/aarch64-openwrt-linux-musl/include/c++/12.2.0/bits/hashtable_policy.h:34,
                 from /builder/shared-workdir/build/sdk/staging_dir/toolchain-aarch64_cortex-a53_gcc-12.2.0_musl/aarch64-openwrt-linux-musl/include/c++/12.2.0/bits/hashtable.h:35,
                 from /builder/shared-workdir/build/sdk/staging_dir/toolchain-aarch64_cortex-a53_gcc-12.2.0_musl/aarch64-openwrt-linux-musl/include/c++/12.2.0/unordered_set:46,
                 from src/main.cpp:17:
/builder/shared-workdir/build/sdk/staging_dir/toolchain-aarch64_cortex-a53_gcc-12.2.0_musl/aarch64-openwrt-linux-musl/include/c++/12.2.0/tuple:1595:45: note: declaration of 'using MyUuid = struct std::array<char, 16>' {aka 'struct std::array<char, 16>'}
 1595 |   template<typename _Tp, size_t _Nm> struct array;
      |                                             ^~~~~
src/main.cpp: In function 'ParsedArgs ParseArgs(int, char**)':
src/main.cpp:178:21: error: 'to_array' is not a member of 'std'
  178 |     res.uuid = std::to_array((char(&)[16])myuuid);
      |                     ^~~~~~~~
src/main.cpp:20:1: note: 'std::to_array' is defined in header '<array>'; did you forget to '#include <array>'?
   19 | #include "protocol.hpp"
  +++ |+#include <array>
   20 | 
make[4]: *** [Makefile:20: /builder/shared-workdir/build/sdk/build_dir/target-aarch64_cortex-a53_musl/udphp-client-2022-12-30-e4ab512a/main.o] Error 1
```

Build-tested with openwrt/gcc 12.2.0.